### PR TITLE
Compatibility with Centos6

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,3 +7,5 @@
 # minimal-security                   = yum --security update-minimal
 # minimal-security-severity:Critical =  --sec-severity=Critical update-minimal
 yum_update_command: minimal-security
+wait_ssh_down_timeout: 120
+wait_ssh_up_timeout: 500

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,3 +1,9 @@
-- name: waitfor_server
-  local_action: wait_for host={{ ansible_host }} state=started port=22 delay=30 timeout=200
+- name: Wait ssh down after server_reboot
+  local_action: wait_for host={{ inventory_hostname }} port=22 delay=0 timeout={{ wait_ssh_down_timeout }} state=stopped
   become: false
+  listen: waitfor_server
+
+- name: Wait ssh up after server reboot 
+  local_action: wait_for host={{ inventory_hostname }} state=started port=22 delay=30 timeout={{ wait_ssh_up_timeout }}
+  become: false
+  listen: waitfor_server

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -56,19 +56,38 @@
   tags:
     - update_all
 
-- name: Check if system needs a reboot
-  command: needs-restarting -r
-  register: reboot_required
-  failed_when: reboot_required.rc not in [0,1]
+- when: ansible_distribution_major_version == "7"
+  block:
+    - name: Check if system needs a reboot
+      command: needs-restarting -r
+      register: reboot_required
+      failed_when: reboot_required.rc not in [0,1]
 
-- name: restart_server
-  command: /usr/bin/systemd-run --on-active=10 /usr/bin/systemctl reboot
-  async: 0
-  poll: 0
-  ignore_errors: true
-  when: reboot_required.rc == 1 and do_reboot is defined
-  notify:
-    - waitfor_server
+    - name: restart_server
+      command: /usr/bin/systemd-run --on-active=10 /usr/bin/systemctl reboot
+      async: 0
+      poll: 0
+      ignore_errors: true
+      when: reboot_required.rc == 1 and do_reboot is defined
+      notify:
+       - waitfor_server
+
+
+- when: ansible_distribution_major_version == "6"
+  block:
+    - name: Check if system needs a reboot
+      command: needs-restarting
+      register: reboot_required
+
+    - name: restart_server
+      shell: sleep 2 && shutdown -r now "Reboot triggered by Ansible" 
+      async: 0
+      poll: 0
+      ignore_errors: true
+      when: reboot_required.stdout != "" and do_reboot is defined
+      notify:
+       - waitfor_server
+
 
 
 


### PR DESCRIPTION
- Add variables for SSH timeouts
- Ensure host SSH is down before waiting to get it up
- Add a switch case for Centos6 needs-restarting invalid option